### PR TITLE
Fix company name spelling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  /* Updated color tokens to match Thomas IKueromitan brand colors */
+  /* Updated color tokens to match Thomas Ikueromitan brand colors */
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(0.98 0 0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const inter = Inter({
 })
 
 export const metadata: Metadata = {
-  title: "Thomas IKueromitan and sons Nigeria Limited - Procurement & Trading",
+  title: "Thomas Ikueromitan and sons Nigeria Limited - Procurement & Trading",
   description:
     "Reliable sourcing in building materials, automobiles, agriculture, and transport & haulage across Nigeria and West Africa.",
   generator: "v0.app",

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -12,7 +12,7 @@ export function Footer() {
                 <span className="text-primary-foreground font-bold text-sm">TIS</span>
               </div>
               <div>
-                <div className="font-manrope font-bold text-lg">Thomas IKueromitan & Sons</div>
+                <div className="font-manrope font-bold text-lg">Thomas Ikueromitan & Sons</div>
                 <div className="text-xs text-muted tracking-wider">NIGERIA LTD</div>
               </div>
             </div>
@@ -102,7 +102,7 @@ export function Footer() {
         </div>
 
         <div className="border-t border-muted/20 mt-12 pt-8 text-center text-sm text-muted">
-          <p>&copy; 2024 Thomas IKueromitan and sons Nigeria Limited. All rights reserved.</p>
+          <p>&copy; 2024 Thomas Ikueromitan and sons Nigeria Limited. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -27,7 +27,7 @@ export function Header() {
                 <span className="text-primary-foreground font-bold text-sm">TIS</span>
               </div>
               <div className="hidden sm:block">
-                <div className="font-manrope font-bold text-lg text-foreground">Thomas IKueromitan & Sons</div>
+                <div className="font-manrope font-bold text-lg text-foreground">Thomas Ikueromitan & Sons</div>
                 <div className="text-xs text-muted-foreground tracking-wider">
                   NIGERIA LTD
                 </div>
@@ -70,7 +70,7 @@ export function Header() {
                     <span className="text-primary-foreground font-bold text-sm">TIS</span>
                   </div>
                   <div>
-                    <div className="font-manrope font-bold text-lg text-foreground">Thomas IKueromitan & Sons</div>
+                    <div className="font-manrope font-bold text-lg text-foreground">Thomas Ikueromitan & Sons</div>
                     <div className="text-xs text-muted-foreground tracking-wider">
                       NIGERIA LTD
                     </div>

--- a/components/whatsapp-floating.tsx
+++ b/components/whatsapp-floating.tsx
@@ -5,7 +5,7 @@ import { MessageCircle } from "lucide-react"
 
 export function WhatsAppFloating() {
   const whatsappUrl =
-    "https://wa.me/2349168295957?text=Hello%20Thomas%20IKueromitan%20and%20Sons%20Nigeria%20Limited%20(LTD)%20%E2%80%94%20I%27d%20like%20to%20request%20a%20quote."
+    "https://wa.me/2349168295957?text=Hello%20Thomas%20Ikueromitan%20and%20Sons%20Nigeria%20Limited%20(LTD)%20%E2%80%94%20I%27d%20like%20to%20request%20a%20quote."
 
   return (
     <div className="fixed bottom-6 right-6 z-50">

--- a/components/why-choose-us.tsx
+++ b/components/why-choose-us.tsx
@@ -34,7 +34,7 @@ export function WhyChooseUs() {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="font-manrope font-bold text-3xl sm:text-4xl text-foreground mb-4">
-            Why Choose Thomas IKueromitan & Sons?
+            Why Choose Thomas Ikueromitan & Sons?
           </h2>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
             Over 15 years of experience delivering reliable procurement and trading services


### PR DESCRIPTION
## Summary
- standardize company name to "Thomas Ikueromitan & Sons" in header, footer, and sections
- update metadata, comments, and WhatsApp link to use corrected spelling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_689f6dc832b08332b5c44cdd7cb99609